### PR TITLE
Fixes #4 - Solve seeds connection

### DIFF
--- a/dispacher.py
+++ b/dispacher.py
@@ -25,6 +25,8 @@ def resultSubscriber(uuid, sizeUrls, peers, htmls, addr):
     #//TODO: Check if 'i' is enough for this condition to be fulfilled
     while i < sizeUrls:
         res = socket.recv_json()
+        if res[0] != "RESULT":
+            continue
         url, html = res[0], res[1]
         log.debug(f"GET {url} OK")
         i += 1

--- a/scrapper.py
+++ b/scrapper.py
@@ -37,7 +37,7 @@ def addClient(clientId, addr, port, clients:dict, clientQueue, uuid):
     except KeyError:
         clients[clientId] = (addr, port)
         clientQueue.put((clientId, (addr, port)))  
-        log.debug(f"Client(id:{id}, address:{addr}) added to the queue of Scrapper:{uuid}")
+        log.debug(f"Client(id:{clientId}, address:{addr}) added to the queue of Scrapper:{uuid}")
     finally:
         lockClients.release()
 

--- a/scrapper.py
+++ b/scrapper.py
@@ -25,7 +25,7 @@ def slave(tasks, uuid):
         log.debug(f"Child:{os.getpid()} of Scrapper:{self.uuid} connecting to {clientAddr}")
         socket.connect(f"tcp://{clientAddr}")
         log.info(f"Child:{os.getpid()} of Scrapper:{self.uuid} sending downloaded content of {url} to {clientAddr}")
-        socket.send_json(response)
+        socket.send_json(("RESULT", response))
         
 def discoverClients(clients:dict, clientQueue, uuid):
     """

--- a/scrapper.py
+++ b/scrapper.py
@@ -1,5 +1,5 @@
 import zmq, logging, time, os, requests, pickle
-from util.params import client_addr, seeds, localhost
+from util.params import seeds, localhost
 from multiprocessing import Process, Lock, Queue
 from threading import Thread, Lock as tLock
 from util.params import format, datefmt, login
@@ -20,12 +20,12 @@ def slave(tasks, uuid):
     socket = context.socket(zmq.REQ)
     while True:
         clientAddr, url = tasks.get() 
-        log.info(f"Child:{os.getpid()} of Scrapper:{self.uuid} downloading {url}")
+        log.info(f"Child:{os.getpid()} of Scrapper:{uuid} downloading {url}")
         response = requests.get(url)
-        log.debug(f"Child:{os.getpid()} of Scrapper:{self.uuid} connecting to {clientAddr}")
+        log.debug(f"Child:{os.getpid()} of Scrapper:{uuid} connecting to {clientAddr}")
         socket.connect(f"tcp://{clientAddr}")
-        log.info(f"Child:{os.getpid()} of Scrapper:{self.uuid} sending downloaded content of {url} to {clientAddr}")
-        socket.send_json(("RESULT", response))
+        log.info(f"Child:{os.getpid()} of Scrapper:{uuid} sending downloaded content of {url} to {clientAddr}")
+        socket.send_json(("RESULT", url, response.text))
         
 def addClient(clientId, addr, port, clients:dict, clientQueue, uuid):
     lockClients.acquire()

--- a/util/params.py
+++ b/util/params.py
@@ -8,9 +8,8 @@ urls = [
 format  = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 datefmt ='%Y-%m-%d %H:%M:%S'
 
-localhost = "localhost"
-client_addr = localhost + ":" + "8101"
-seeds = [localhost + ":" + "8102"]
+localhost = "127.0.0.1"
+seeds = [(localhost, 8101)]
 
 login = "DISTRIBUTED-SCRAPPER"
 

--- a/util/params.py
+++ b/util/params.py
@@ -11,3 +11,20 @@ datefmt ='%Y-%m-%d %H:%M:%S'
 localhost = "localhost"
 client_addr = localhost + ":" + "8101"
 seeds = [localhost + ":" + "8102"]
+
+login = "DISTRIBUTED-SCRAPPER"
+
+#//TODO: Add this description to README.md
+"""
+
+List of port usage:
+
+Scrapper-Seed:
+main_port(mp): to publish NEW_CLIENT
+mp + 1:        to receive new clients
+
+Dispacher:
+mp:            to push tasks
+mp + 1:        to receive results
+
+"""


### PR DESCRIPTION
Changes:
- Add loads of TODO and HACK tag comments.
- Add service for the dispacher to connect to the seeds.
- Add service for the scrapper-seed to receive new clients and to publish them to the other peers.
- Change the way of updating the pool of urls in dispacher.
- Update the process of scrapping an URL and sending it to the client from a slave process on the scrapper.

Require testing:
No