### PR TITLE
Fixes #34 - Add features for sharing states between seed nodes

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -36,6 +36,7 @@ class Dispatcher:
         context = zmq.Context()
         socket = noBlockREQ(context)
 
+        #//TODO: Connect to seeds in a way that a new seed can be added
         for addr, port in seeds:
             socket.connect(f"tcp://{addr}:{port}")
             log.info(f"connected to {addr}:{port}", "dispatch")

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -49,7 +49,6 @@ class Dispatcher:
         while len(self.urls):
             try:
                 url = self.urls[0]
-                #//HACK: We need to create a socket every time?
                 socket.send_json(("URL", url))
                 log.debug(f"send {url}", "dispatch")
                 response = socket.recv_json()

--- a/scrapper.py
+++ b/scrapper.py
@@ -22,7 +22,7 @@ def slave(tasks, notifications, uuid, idx):
         with availableSlaves:
             availableSlaves.value -= 1
         log.info(f"Child:{os.getpid()} of Scrapper:{uuid} downloading {url}", f"slave {idx}")
-        #//TODO: Handle request connection error
+        #//TODO: Handle better a request connection error, we retry it a few times?
         try:
             response = requests.get(url)
         except Exception as e:

--- a/scrapper.py
+++ b/scrapper.py
@@ -23,7 +23,11 @@ def slave(tasks, notifications, uuid, idx):
             availableSlaves.value -= 1
         log.info(f"Child:{os.getpid()} of Scrapper:{uuid} downloading {url}", f"slave {idx}")
         #//TODO: Handle request connection error
-        response = requests.get(url)
+        try:
+            response = requests.get(url)
+        except Exception as e:
+            log.error(e, f"slave {idx}")
+            continue
         notifications.put(("DONE", url, response.text))
         with availableSlaves:
             availableSlaves.value += 1
@@ -42,6 +46,7 @@ def notifier(notifications):
     context = zmq.Context()
     socket = noBlockREQ(context)
 
+    #//TODO: Connect to seeds in a way that a new seed can be added
     for addr, port in seeds:
         socket.connect(f"tcp://{addr}:{port + 2}")
 
@@ -81,6 +86,7 @@ class Scrapper:
         context = zmq.Context()
         socketPull = context.socket(zmq.PULL)
         
+        #//TODO: Connect to seeds in a way that a new seed can be added
         for addr, port in seeds:
             socketPull.connect(f"tcp://{addr}:{port + 1}")
             log.info(f"Scrapper:{self.uuid} connected to seed with address:{addr}:{port + 1})", "manage")

--- a/scrapper.py
+++ b/scrapper.py
@@ -21,7 +21,7 @@ def slave(tasks, notifications, uuid, idx):
         url = tasks.get() 
         with availableSlaves:
             availableSlaves.value -= 1
-        log.info(f"Child:{os.getpid()} of Scrapper:{uuid} downloading {url}", f"slave{idx}")
+        log.info(f"Child:{os.getpid()} of Scrapper:{uuid} downloading {url}", f"slave {idx}")
         #//TODO: Handle request connection error
         response = requests.get(url)
         notifications.put(("DONE", url, response.text))

--- a/seed.py
+++ b/seed.py
@@ -187,7 +187,7 @@ class Seed:
             seedsToConnect.remove((self.addr, self.port))
         except ValueError:
             log.error(f"Unknown seed at {(self.addr, self.port)}", "Serve")
-        sList = map(seedsToConnect, lambda x: f"{x[0]}:{x[1]}")
+        sList = map(lambda x: f"{x[0]}:{x[1]}", seedsToConnect)
        
         tasksQ = Queue()
         pGetRemoteTasks = Process(target=getRemoteTasks, name="Get Remote Tasks", args=(sList, tasksQ))

--- a/seed.py
+++ b/seed.py
@@ -1,12 +1,14 @@
-import zmq, time, queue
+import zmq, time, queue, pickle
 from multiprocessing import Process, Queue
 from threading import Thread, Lock as tLock
+from util.params import seeds
 from util.utils import parseLevel, LoggerFactory as Logger
 
 log = Logger(name="Seed")
 pMainLog = "main"
 
 lockTasks = tLock()
+lockSubscriber = tLock()
 
 def pushTask(toPushQ, addr):
     """
@@ -48,7 +50,7 @@ def workerAttender(pulledQ, resultQ, addr):
             continue
 
             
-def taskManager(tasks, q):
+def taskManager(tasks, q, toPubQ):
     """
     Thread that helps the seed main process to update the tasks map.
     """
@@ -58,8 +60,65 @@ def taskManager(tasks, q):
             with lockTasks:
                 tasks[url] = (flag, data)
                 #publish to other seeds
+                toPubQ.put((flag, url, data))
         except queue.Empty:
             time.sleep(1)  
+
+
+def taskPublisher(addr, taskQ):
+    """
+    Process that publish tasks changes to others seed nodes.
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.PUB)
+    socket.bind(f"tcp://{addr}")
+
+    while True:
+        try:
+            #task: (flag, url, data)
+            task = taskQ.get()
+            log.debug(f"Publish task: ({task[0]}, {task[1]})", "Task Publisher")
+            socket.send_multipart([b"TASK", pickle.dumps(task)])
+        except Exception as e:
+            log.error(e, "Task Publisher")
+
+
+def connectToPublishers(socket, addr, port, peerQ):
+    """
+    Thread that connect subscriber socket to seeds.
+    """
+    while True:
+        pAddr, pPort = peerQ.get()
+        #//TODO: Ask for address to, now we are testing with localhost for everybody
+        if pPort != port:
+            with lockSubscriber:
+                log.debug(f"Connecting to seed {pAddr}:{pPort + 3}","Connect to Publishers")
+                socket.connect(f"tcp://{pAddr}:{pPort + 3}")
+
+
+def taskSubscriber(tasks, addr, port, peerQ):
+    """
+    Process that subscribe to published tasks
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.SUB)
+    socket.setsockopt(zmq.SUBSCRIBE, b"TASK")
+
+    connectT = Thread(target=connectToPublishers, name="Connect to Publishers", args=(socket, addr, port, peerQ))
+    connectT.start()
+    time.sleep(1)
+
+    while True:
+        try:
+            #task: (flag, url, data)
+            with lockSubscriber:
+                header, task = socket.recv_multipart()
+                flag, url, data = pickle.loads(task)
+                log.debug(f"Received Subscribed message: ({header.decode()}, {flag}, {url})", "Task Subscriber")
+                with lockTasks:
+                    tasks[url] = (flag, data)
+        except Exception as e:
+            log.error(e, "Task Subscriber")
 
 
 class Seed:
@@ -84,14 +143,26 @@ class Seed:
         pushQ = Queue()
         pulledQ = Queue()
         resultQ = Queue()
+        taskToPubQ = Queue()
+        seedsQ = Queue()
+
+        #//HACK: When a new seed enter the system, his address and port must be inserted in seedsQ
+        for s in seeds:
+            seedsQ.put(s)
 
         pPush = Process(target=pushTask, name="Task Pusher", args=(pushQ, f"{self.addr}:{self.port + 1}"))
         pWorkerAttender = Process(target=workerAttender, name="Worker Attender", args=(pulledQ, resultQ, f"{self.addr}:{self.port + 2}"))
-        taskManager1T = Thread(target=taskManager, name="Task Manager", args=(self.tasks, pulledQ))
-        taskManager2T = Thread(target=taskManager, name="Task Manager", args=(self.tasks, resultQ))
+        pTaskPublisher = Process(target=taskPublisher, name="Task Publisher", args=(f"{self.addr}:{self.port + 3}", taskToPubQ))
+        pTaskSubscriber = Process(target=taskSubscriber, name="Task Subscriber", args=(self.tasks, self.addr, self.port, seedsQ))
+
+        taskManager1T = Thread(target=taskManager, name="Task Manager", args=(self.tasks, pulledQ, taskToPubQ))
+        taskManager2T = Thread(target=taskManager, name="Task Manager", args=(self.tasks, resultQ, taskToPubQ))
 
         pPush.start()
         pWorkerAttender.start()
+        pTaskPublisher.start()
+        pTaskSubscriber.start()
+
         taskManager1T.start()
         taskManager2T.start()
 

--- a/util/params.py
+++ b/util/params.py
@@ -20,7 +20,7 @@ login = "DISTRIBUTED-SCRAPPER"
 
 List of port usage:
 
-Scrapper-Seed:
+Scrapper:
 main_port(mp): to publish NEW_CLIENT
 mp + 1:        to receive new clients
 
@@ -28,4 +28,9 @@ Dispacher:
 mp:            to push tasks
 mp + 1:        to receive results
 
+Seed:
+mp:            to attend clients
+mp + 1:        to push tasks
+mp + 2:        to attend scrappers
+mp + 3:        to publish new tasks to seeds
 """


### PR DESCRIPTION
Fixes #34 

Changes:
- Add RPC to get the tasks for a seed from other seed
- Add a thread for clean the task map from time to time
- Use a publish-subscribe pattern to share the states of task map between seed nodes