### PR TITLE
Fixes #35 - Create a verification mechanism

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -54,6 +54,7 @@ class Dispatcher:
                 response = socket.recv_json()
                 assert len(response) == 2, "bad response size"
                 download, html = response
+                log.debug(f"Received {download}", "dispatch")
                 self.urls.pop(0)
                 if download:
                     log.info(f"{url} {GREEN}OK{RESET}", "dispatch")

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -41,8 +41,8 @@ class Dispatcher:
             socket.connect(f"tcp://{addr}:{port}")
             log.info(f"connected to {addr}:{port}", "dispatch")
 
-        downloadsQueue = Queue()
-        pWriter = Process(target=downloadsWriter, args=(downloadsQueue,))
+        downloadsQ = Queue()
+        pWriter = Process(target=downloadsWriter, args=(downloadsQ,))
         pWriter.start()
 
         idx = {url: i for i, url in enumerate(self.urls)}
@@ -58,7 +58,7 @@ class Dispatcher:
                 self.urls.pop(0)
                 if download:
                     log.info(f"{url} {GREEN}OK{RESET}", "dispatch")
-                    downloadsQueue.put((idx[url], url, html))
+                    downloadsQ.put((idx[url], url, html))
                 else:
                     self.urls.append(url)
             except AssertionError as e:
@@ -74,7 +74,7 @@ class Dispatcher:
         log.debug(f"Dispatcher:{self.uuid} disconnecting from system", "dispatch")
         #disconnect
 
-        downloadsQueue.put("STOP")
+        downloadsQ.put("STOP")
         pWriter.join()
         queue.put(True)
         

--- a/scrapper.py
+++ b/scrapper.py
@@ -94,18 +94,18 @@ class Scrapper:
             socketPull.connect(f"tcp://{addr}:{port + 1}")
             log.info(f"Scrapper connected to seed with address:{addr}:{port + 1})", "manage")
         
-        notificationsQueue = Queue()
-        pNotifier = Process(target=notifier, name="pNotifier", args=(notificationsQueue,))
+        notificationsQ = Queue()
+        pNotifier = Process(target=notifier, name="pNotifier", args=(notificationsQ,))
         pNotifier.start()
         
         pListen = Process(target=listener, name="pListen", args=(self.addr, self.port))
         pListen.start()
         
-        taskQueue = Queue()
+        taskQ = Queue()
         log.info(f"Scrapper starting child process", "manage")
         availableSlaves.value = slaves
         for i in range(slaves):
-            p = Process(target=slave, args=(taskQueue, notificationsQueue, i))
+            p = Process(target=slave, args=(taskQ, notificationsQ, i))
             p.start()
             log.debug(f"Scrapper has started a child process with pid:{p.pid}", "manage")
 
@@ -116,8 +116,8 @@ class Scrapper:
                 if availableSlaves.value > 0:
                     log.debug(f"Available Slaves: {availableSlaves.value}", "manage")
                     url = socketPull.recv().decode()
-                    taskQueue.put(url)
-                    notificationsQueue.put(("PULLED", url, addr))
+                    taskQ.put(url)
+                    notificationsQ.put(("PULLED", url, addr))
                     log.debug(f"Pulled {url} in scrapper", "manage")
             time.sleep(1)
             

--- a/scrapper.py
+++ b/scrapper.py
@@ -32,6 +32,7 @@ def slave(tasks, notifications, idx):
                     notifications.put(("FAILED", url, i))
                 continue
             notifications.put(("DONE", url, response.text))
+            break
         with availableSlaves:
             availableSlaves.value += 1
     

--- a/seed.py
+++ b/seed.py
@@ -166,7 +166,7 @@ def purger(tasks, cycle):
             for url in tmpTask:
                 if tmpTask[url][0]:
                     tasks.pop(url)
-        log.debug(f"Purged tasks: {tasks}", "Purger")
+        log.debug(f"Tasks after purge: {tasks}", "Purger")
         log.debug("Purge finished", "Purger")
         time.sleep(cycle)
 
@@ -261,6 +261,7 @@ class Seed:
         pWorkerAttender.start()
         pTaskPublisher.start()
         pTaskSubscriber.start()
+        pVerifier.start()
 
         taskManager1T.start()
         taskManager2T.start()
@@ -279,7 +280,8 @@ class Seed:
                             res = self.tasks[url]
                             if not res[0]:
                                 if isinstance(res[1], list):
-                                    verificationQ.put(res[1], url)
+                                    log.debug(f"Verificating {url} in the system...", "serve")
+                                    verificationQ.put((res[1], url))
                                 elif url == res[1]:
                                     raise KeyError
                         except KeyError:

--- a/seed.py
+++ b/seed.py
@@ -16,6 +16,7 @@ def verificator(queue, t, pushQ):
         pQuick = Process(target=quickVerification, args=(address, url, t, ansQ))
         pQuick.start()
         ans = ansQ.get()
+        pQuick.terminate()
         if not ans:
             pushQ.put(url)
             

--- a/seed.py
+++ b/seed.py
@@ -17,9 +17,9 @@ def quickVerification(address, url, t, queue):
         socket.connect(f"tcp://{addr}:{port}")
         socket.send(url.encode())
         ans = socket.recv_json()
-        log.debug(f"worker at {address} is alive", "Quick Verification")
+        log.debug(f"Worker at {address} is alive", "Quick Verification")
     except zmq.error.Again:
-        log.debug(f"worker at {address} unavailabe", "Quick Verification")
+        log.debug(f"Worker at {address} unavailable", "Quick Verification")
     except Exception as e:
         log.error(e, "Quick Verification")
     finally:


### PR DESCRIPTION
Fixes #35 

Changes:
- Added `quickVerification` to communicate with workers that has an assigned task

Verification occur before the seed send a response to a client