### PR TITLE
Fixes #18 - Update login and discovery method of nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 
 downloads/
+
+network.txt

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ edit: ## Open the Makefile in editor
 dispatcher: ## Run a dispatcher with default params
 	python dispatcher.py
 
+dispatcher-remote: ## Run a dispatcher with default params and with seed address atached
+	python dispatcher.py -s 127.0.0.1:8101
+
 seed: ## Run a scrapper with default params and seeder flag on
 	python seed.py
 

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -1,11 +1,15 @@
-import zmq, time
-from util.params import urls, seeds
+import zmq, time, re
+from util.params import urls
 from util.colors import GREEN, RESET
 from multiprocessing import Process, Queue
-from util.utils import parseLevel, makeUuid, LoggerFactory as Logger, noBlockREQ
+from util.utils import parseLevel, makeUuid, LoggerFactory as Logger, noBlockREQ, discoverPeer, getSeeds, findSeeds
+from threading import Thread, Lock as tLock, Semaphore
 
 
 log = Logger(name="Dispatcher")
+
+lockSocketReq = tLock()
+counterSocketReq = Semaphore()
 
 
 def downloadsWriter(queue):
@@ -15,7 +19,31 @@ def downloadsWriter(queue):
             fd.write(data)
     log.debug("All data saved")
   
-            
+
+def connectToSeeds(sock, peerQ):
+    """
+    Thread that connect REQ socket to seeds.
+    """
+    for addr, port in iter(peerQ.get, "STOP"):
+        with lockSocketReq:
+            log.debug(f"Connecting to seed {addr}:{port}","Connect to Seeds")
+            sock.connect(f"tcp://{addr}:{port}")
+            counterSocketReq.release()
+            log.info(f"Dispatcher connected to seed with address:{addr}:{port})", "Connect to Seeds")
+
+
+def disconnectToSeeds(sock, peerQ):
+    """
+    Thread that disconnect REQ socket to seeds.
+    """
+    for addr, port in iter(peerQ.get, "STOP"):
+        with lockSocketReq:
+            log.debug(f"Disconnecting to seed {addr}:{port}","Disconnect to Seeds")
+            sock.disconnect(f"tcp://{addr}:{port}")
+            counterSocketReq.acquire()
+            log.info(f"Dispatcher disconnected to seed with address:{addr}:{port})", "Disconnect to Seeds")
+
+
 class Dispatcher:
     """
     Represents a client to the services of the Scrapper.
@@ -29,17 +57,63 @@ class Dispatcher:
 
         log.debug(f"Dispatcher created with uuid {uuid}", "Init")
         
+
+    def login(self, seed):
+        """
+        Login the node in the system.
+        """
+        network = True
+        if seed is not None:
+            #ip_address:port_number
+            regex = re.compile("\d{,3}\.\d{,3}\.\d{,3}\.\d{,3}:\d+")
+            try:
+                assert regex.match(seed).end() == len(seed)
+            except (AssertionError, AttributeError):
+                log.error(f"Parameter seed inserted is not a valid ip_address:port_number")
+                seed = None
+
+        if seed is None:
+            #//TODO: Change times param in production
+            log.debug("Discovering seed nodes", "login")
+            seed, network = discoverPeer(3, log)
+            if seed == "":
+                log.error("Login failed, get the address of a active master node or connect to the same network that the service", "login")
+                return False
+
+        seedsQ = Queue()
+        pGetSeeds = Process(target=getSeeds, name="Get Seeds", args=(seed, discoverPeer, (self.address, self.port), False, seedsQ, log))
+        pGetSeeds.start()
+        self.seeds = seedsQ.get()
+        pGetSeeds.terminate()
+
+        if not len(self.seeds):
+            log.error("Login failed, get the address of a active master node or connect to the same network that the service", "login")
+            return False
+
+        log.info("Login finished", "login")
+        return network
+
+
     def dispatch(self, queue):
         """
         Start to serve the Dispatcher.
         """
         context = zmq.Context()
         socket = noBlockREQ(context)
+        
+        seedsQ = Queue()
+        for address in self.seeds:
+            seedsQ.put(address)
 
-        #//TODO: Connect to seeds in a way that a new seed can be added
-        for addr, port in seeds:
-            socket.connect(f"tcp://{addr}:{port}")
-            log.info(f"connected to {addr}:{port}", "dispatch")
+        connectT = Thread(target=connectToSeeds, name="Connect to Seeds", args=(socket, seedsQ))
+        connectT.start()
+
+        toDisconnectQ = Queue()
+        disconnectT = Thread(target=disconnectToSeeds, name="Disconnect to Seeds", args=(socket, toDisconnectQ))
+        disconnectT.start()
+
+        pFindSeeds = Process(target=findSeeds, name="Find Seeds", args=(set(self.seeds), [seedsQ], [toDisconnectQ], log, 2000, 10))
+        pFindSeeds.start()
 
         downloadsQ = Queue()
         pWriter = Process(target=downloadsWriter, args=(downloadsQ,))
@@ -49,9 +123,10 @@ class Dispatcher:
         while len(self.urls):
             try:
                 url = self.urls[0]
-                socket.send_json(("URL", url))
-                log.debug(f"send {url}", "dispatch")
-                response = socket.recv_json()
+                with counterSocketReq:
+                    socket.send_json(("URL", url))
+                    log.debug(f"send {url}", "dispatch")
+                    response = socket.recv_json()
                 assert len(response) == 2, "bad response size"
                 download, html = response
                 log.debug(f"Received {download}", "dispatch")
@@ -77,14 +152,16 @@ class Dispatcher:
         downloadsQ.put("STOP")
         pWriter.join()
         queue.put(True)
+        pFindSeeds.terminate()
         
         
-
 def main(args):
     log.setLevel(parseLevel(args.level))
     
     uuid = makeUuid(2**55, urls)
     d = Dispatcher(urls, uuid, args.address, args.port)
+    if not d.login(args.seed):
+        return
     terminateQ = Queue()
     pDispatch = Process(target=d.dispatch, args=(terminateQ,))
     pDispatch.start()
@@ -97,9 +174,11 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description='Client of a distibuted scrapper')
-    parser.add_argument('-p', '--port', type=int, default=4142, help='connection port')
     parser.add_argument('-a', '--address', type=str, default='127.0.0.1', help='node address')
+    parser.add_argument('-p', '--port', type=int, default=4142, help='connection port')
     parser.add_argument('-l', '--level', type=str, default='DEBUG', help='log level')
+    parser.add_argument('-s', '--seed', type=str, default=None, help='address of a existing seed node. Insert as ip_address:port_number')
+
 
     #//TODO: use another arg to set the path to a file that contains the set of urls
 

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -9,7 +9,7 @@ from threading import Thread, Lock as tLock, Semaphore
 log = Logger(name="Dispatcher")
 
 lockSocketReq = tLock()
-counterSocketReq = Semaphore()
+counterSocketReq = Semaphore(value=0)
 
 
 def downloadsWriter(queue):
@@ -129,12 +129,13 @@ class Dispatcher:
                     response = socket.recv_json()
                 assert len(response) == 2, "bad response size"
                 download, html = response
-                log.debug(f"Received {download}", "dispatch")
                 self.urls.pop(0)
                 if download:
+                    log.debug(f"Received {download}", "dispatch")
                     log.info(f"{url} {GREEN}OK{RESET}", "dispatch")
                     downloadsQ.put((idx[url], url, html))
                 else:
+                    log.debug(f"Received {download, html}", "dispatch")
                     self.urls.append(url)
             except AssertionError as e:
                 log.error(e, "dispatch")

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -161,14 +161,20 @@ def main(args):
     
     uuid = makeUuid(2**55, urls)
     d = Dispatcher(urls, uuid, args.address, args.port)
-    if not d.login(args.seed):
-        return
-    terminateQ = Queue()
-    pDispatch = Process(target=d.dispatch, args=(terminateQ,))
-    pDispatch.start()
-    terminateQ.get()
-    log.info(f"Dispatcher:{uuid} finish!!!", "main")
-    pDispatch.terminate()
+    seed = args.seed
+    while not d.login(seed):
+        log.info("Enter an address of an existing seed node. Insert as ip_address:port_number. Press ENTER if you want to omit this address. Press q if you want to exit the program")
+        seed = input("-->")
+        seed = seed.split()[0]
+        if seed == 'q':
+            break
+    if seed != 'q':
+        terminateQ = Queue()
+        pDispatch = Process(target=d.dispatch, args=(terminateQ,))
+        pDispatch.start()
+        terminateQ.get()
+        log.info(f"Dispatcher:{uuid} finish!!!", "main")
+        pDispatch.terminate()
 
 
 if __name__ == "__main__":
@@ -178,7 +184,7 @@ if __name__ == "__main__":
     parser.add_argument('-a', '--address', type=str, default='127.0.0.1', help='node address')
     parser.add_argument('-p', '--port', type=int, default=4142, help='connection port')
     parser.add_argument('-l', '--level', type=str, default='DEBUG', help='log level')
-    parser.add_argument('-s', '--seed', type=str, default=None, help='address of a existing seed node. Insert as ip_address:port_number')
+    parser.add_argument('-s', '--seed', type=str, default=None, help='address of an existing seed node. Insert as ip_address:port_number')
 
 
     #//TODO: use another arg to set the path to a file that contains the set of urls

--- a/scrapper.py
+++ b/scrapper.py
@@ -3,7 +3,7 @@ from util.params import seeds, localhost
 from multiprocessing import Process, Lock, Queue, Value
 from ctypes import c_int
 from threading import Thread, Lock as tLock
-from util.utils import parseLevel, LoggerFactory as Logger, noBlockREQ
+from util.utils import parseLevel, LoggerFactory as Logger, noBlockREQ, discoverPeer, getSeeds
 
 
 log = Logger(name="Scrapper")
@@ -12,6 +12,7 @@ availableSlaves = Value(c_int)
 
 lockClients = tLock()
 lockSocketPull = tLock()
+
 
 def slave(tasks, notifications, idx):
     """
@@ -73,6 +74,77 @@ def notifier(notifications):
                 log.error(e, "Worker Notifier")
         
         
+def connectToSeeds(sock, peerQ):
+    """
+    Thread that connect pull socket to seeds.
+    """
+    for addr, port in iter(peerQ.get, "STOP"):
+        with lockSocketPull:
+            log.debug(f"Connecting to seed {addr}:{port + 1}","Connect to Seeds")
+            sock.connect(f"tcp://{addr}:{port + 1}")
+            log.info(f"Scrapper connected to seed with address:{addr}:{port + 1})", "Connect to Seeds")
+
+
+def ping(seed, q):
+    """
+    Process that make ping to a seed.
+    """
+    context = zmq.Context()
+    socket = noBlockREQ(context, timeout=1000)
+    socket.connect(f"tcp://{seed[0]}:{seed[1]}")
+    status = True
+
+    log.debug(f"PING to {seed[0]}:{seed[1]}", "Ping")
+    try:
+        socket.send_json(("PING",))
+        msg = socket.recv_json()
+        log.debug(f"Received {msg} from {seed[0]}:{seed[1]} after ping", "Ping")
+    except zmq.error.Again as e:
+        log.debug(e, "Ping")
+        status = False
+    q.put(status)
+
+
+def findSeeds(seeds, peerQ):
+    """
+    Process that ask to a seed for his list of seeds.
+    """
+    time.sleep(15)
+    while True:
+        #random address
+        seed = (localhost, 9999)
+        for s in seeds:
+            #This process is useful to know if a seed is dead too
+            seed = s
+            pingQ = Queue()
+            pPing = Process(target=ping, name="Ping", args=(s, pingQ))
+            pPing.start()
+            status = pingQ.get()
+            pPing.terminate()
+            if status:
+                break
+        seedsQ = Queue()
+        pGetSeeds = Process(target=getSeeds, name="Get Seeds", args=(f"{seed[0]}:{seed[1]}", discoverPeer, None, False, seedsQ, log))
+        log.debug("Finding new seeds to pull from...", "Find Seeds")
+        pGetSeeds.start()
+        tmp = set(seedsQ.get())
+        pGetSeeds.terminate()
+        #If Get Seeds succeds to connect to a seed
+        if len(tmp) != 0:
+            dif = tmp - seeds
+            if not len(dif):
+                log.debug("No new seed nodes where finded", "Find Seeds")
+            else:
+                log.debug("New seed nodes where finded", "Find Seeds")
+
+            for s in tmp - seeds:
+                peerQ.put(s)
+            seeds.update(tmp)
+
+        #//TODO: Change the amount of the sleep in production
+        time.sleep(15)
+
+
 class Scrapper:
     """
     Represents a scrapper, the worker node in the Scrapper network.
@@ -83,6 +155,40 @@ class Scrapper:
         
         log.debug(f"Scrapper created", "init")
 
+
+    def login(self, seed):
+        """
+        Login the node in the system.
+        """
+        network = True
+        if seed is not None:
+            #ip_address:port_number
+            regex = re.compile("\d{,3}\.\d{,3}\.\d{,3}\.\d{,3}:\d+")
+            try:
+                assert regex.match(seed).end() == len(seed)
+            except (AssertionError, AttributeError):
+                log.error(f"Parameter seed inserted is not a valid ip_address:port_number")
+                seed = None
+
+        if seed is None:
+            #//TODO: Change times param in production
+            log.debug("Discovering seed nodes", "login")
+            seed, network = discoverPeer(3, log)
+            if seed == "":
+                self.seeds = list()
+                log.info("Login finished", "login")
+                return network
+
+        seedsQ = Queue()
+        pGetSeeds = Process(target=getSeeds, name="Get Seeds", args=(seed, discoverPeer, (self.addr, self.port), False, seedsQ, log))
+        pGetSeeds.start()
+        self.seeds = seedsQ.get()
+        pGetSeeds.terminate()
+
+        log.info("Login finished", "login")
+        return network
+
+
     def manage(self, slaves):
         """
         Start to manage childs-slaves.
@@ -90,10 +196,15 @@ class Scrapper:
         context = zmq.Context()
         socketPull = context.socket(zmq.PULL)
         
-        #//TODO: Connect to seeds in a way that a new seed can be added
-        for addr, port in seeds:
-            socketPull.connect(f"tcp://{addr}:{port + 1}")
-            log.info(f"Scrapper connected to seed with address:{addr}:{port + 1})", "manage")
+        seedsQ = Queue()
+        for address in self.seeds:
+            seedsQ.put(address)
+
+        connectT = Thread(target=connectToSeeds, name="Connect to Seeds", args=(socketPull, seedsQ))
+        connectT.start()
+
+        pFindSeeds = Process(target=findSeeds, name="Find Seeds", args=(set(self.seeds), seedsQ))
+        pFindSeeds.start()
         
         notificationsQ = Queue()
         pNotifier = Process(target=notifier, name="pNotifier", args=(notificationsQ,))
@@ -129,6 +240,9 @@ class Scrapper:
 def main(args):
     log.setLevel(parseLevel(args.level))
     s = Scrapper(port=args.port, address=args.address)
+    network = s.login(args.seed)
+    if not network:
+        log.info("You are not connected to a network", "main") 
     s.manage(2)
 
             
@@ -139,6 +253,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--port', type=int, default=5050, help='connection port')
     parser.add_argument('-a', '--address', type=str, default='127.0.0.1', help='node address')
     parser.add_argument('-l', '--level', type=str, default='DEBUG', help='log level')
+    parser.add_argument('-s', '--seed', type=str, default=None, help='address of a existing seed node. Insert as ip_address:port_number')
 
     args = parser.parse_args()
 

--- a/scrapper.py
+++ b/scrapper.py
@@ -70,7 +70,7 @@ def disconnectFromSeeds1(sock, peerQ):
             log.debug(f"Disconnecting from seed {addr}:{port + 1}","Disconnect from Seeds1")
             sock.disconnect(f"tcp://{addr}:{port + 1}")
             counterSocketPull.acquire()
-            log.info(f"Dispatcher disconnected from seed with address:{addr}:{port + 1})", "Disconnect from Seeds1")
+            log.info(f"Scrapper disconnected from seed with address:{addr}:{port + 1})", "Disconnect from Seeds1")
 
 
 def connectToSeeds2(sock, peerQ):
@@ -94,7 +94,7 @@ def disconnectFromSeeds2(sock, peerQ):
             log.debug(f"Disconnecting from seed {addr}:{port + 2}","Disconnect from Seeds2")
             sock.disconnect(f"tcp://{addr}:{port + 2}")
             counterSocketNotifier.acquire()
-            log.info(f"Dispatcher disconnected from seed with address:{addr}:{port + 2})", "Disconnect from Seeds2")
+            log.info(f"Scrapper disconnected from seed with address:{addr}:{port + 2})", "Disconnect from Seeds2")
 
 
 def notifier(notifications, peerQ, deadQ):

--- a/scrapper.py
+++ b/scrapper.py
@@ -61,16 +61,16 @@ def connectToSeeds1(sock, peerQ):
             log.info(f"Scrapper connected to seed with address:{addr}:{port + 1})", "Connect to Seeds1")
 
 
-def disconnectToSeeds1(sock, peerQ):
+def disconnectFromSeeds1(sock, peerQ):
     """
-    Thread that disconnect pull socket of seeds.
+    Thread that disconnect pull socket from seeds.
     """
     for addr, port in iter(peerQ.get, "STOP"):
         with lockSocketPull:
-            log.debug(f"Disconnecting of seed {addr}:{port + 1}","Disconnect to Seeds1")
+            log.debug(f"Disconnecting of seed {addr}:{port + 1}","Disconnect from Seeds1")
             sock.disconnect(f"tcp://{addr}:{port + 1}")
             counterSocketPull.acquire()
-            log.info(f"Dispatcher disconnected of seed with address:{addr}:{port + 1})", "Disconnect to Seeds1")
+            log.info(f"Dispatcher disconnected of seed with address:{addr}:{port + 1})", "Disconnect from Seeds1")
 
 
 def connectToSeeds2(sock, peerQ):
@@ -85,16 +85,16 @@ def connectToSeeds2(sock, peerQ):
             log.info(f"Scrapper connected to seed with address:{addr}:{port + 2})", "Connect to Seeds2")
     
 
-def disconnectToSeeds2(sock, peerQ):
+def disconnectFromSeeds2(sock, peerQ):
     """
-    Thread that disconnect REQ socket of seeds.
+    Thread that disconnect REQ socket from seeds.
     """
     for addr, port in iter(peerQ.get, "STOP"):
         with lockSocketNotifier:
-            log.debug(f"Disconnecting of seed {addr}:{port + 2}","Disconnect to Seeds2")
+            log.debug(f"Disconnecting of seed {addr}:{port + 2}","Disconnect from Seeds2")
             sock.disconnect(f"tcp://{addr}:{port + 2}")
             counterSocketNotifier.acquire()
-            log.info(f"Dispatcher disconnected of seed with address:{addr}:{port + 2})", "Disconnect to Seeds2")
+            log.info(f"Dispatcher disconnected of seed with address:{addr}:{port + 2})", "Disconnect from Seeds2")
 
 
 def notifier(notifications, peerQ, deadQ):
@@ -105,7 +105,7 @@ def notifier(notifications, peerQ, deadQ):
     connectT = Thread(target=connectToSeeds2, name="Connect to Seeds", args=(socket, peerQ))
     connectT.start()
 
-    disconnectT = Thread(target=disconnectToSeeds2, name="Disconnect to Seeds", args=(socket, deadQ))
+    disconnectT = Thread(target=disconnectFromSeeds2, name="Disconnect from Seeds", args=(socket, deadQ))
     disconnectT.start()
 
     for msg in iter(notifications.get, "STOP"):
@@ -191,7 +191,7 @@ class Scrapper:
         toDisconnectQ1 = Queue()
         toDisconnectQ2 = Queue()
 
-        disconnectT = Thread(target=disconnectToSeeds1, name="Disconnect to Seeds", args=(socketPull, toDisconnectQ1))
+        disconnectT = Thread(target=disconnectFromSeeds1, name="Disconnect from Seeds", args=(socketPull, toDisconnectQ1))
         disconnectT.start()
 
         pFindSeeds = Process(target=findSeeds, name="Find Seeds", args=(set(self.seeds), [seedsQ1, seedsQ2], [toDisconnectQ1, toDisconnectQ2], log))

--- a/seed.py
+++ b/seed.py
@@ -1,7 +1,7 @@
 import zmq, time, queue, pickle, re
 from multiprocessing import Process, Queue
 from threading import Thread, Lock as tLock
-from util.params import seeds, login, BROADCAST_PORT
+from util.params import login, BROADCAST_PORT
 from util.utils import parseLevel, LoggerFactory as Logger, noBlockREQ, discoverPeer, getSeeds
 from socket import *
 
@@ -396,8 +396,7 @@ class Seed:
 def main(args):
     log.setLevel(parseLevel(args.level))
     s = Seed(args.address, args.port)
-    network = s.login(args.seed)
-    if not network:
+    if not s.login(args.seed):
         log.info("You are not connected to a network", "main") 
     s.serve(args.broadcast_port)
 

--- a/seed.py
+++ b/seed.py
@@ -31,6 +31,7 @@ def quickVerification(address, url, t, queue):
     try:
         addr, port = address
         sock.connect(f"tcp://{addr}:{port}")
+        log.debug(f"Sending quick verification to {addr}:{port}", "Quick Verification")
         sock.send(url.encode())
         ans = sock.recv_json()
         log.debug(f"Worker at {address} is alive", "Quick Verification")
@@ -361,8 +362,12 @@ class Seed:
                                     verificationQ.put((res[1], url))
                                 elif url == res[1]:
                                     raise KeyError
+                                else:
+                                    self.tasks[url][1] += 1
+                                    if self.tasks[url][1] == 10:
+                                        raise KeyError       
                         except KeyError:
-                            res = self.tasks[url] = [False, "Pushed"]
+                            res = self.tasks[url] = [False, 0]
                             pushQ.put(url)
                     sock.send_json(res)
                 elif msg[0] == "GET_TASKS":

--- a/seed.py
+++ b/seed.py
@@ -87,15 +87,12 @@ def taskManager(tasks, q, toPubQ, pub):
     Thread that helps the seed main process to update the tasks map.
     """
     while True:
-        try:
-            flag, url, data = q.get()
-            with lockTasks:
-                tasks[url] = (flag, data)
-                #publish to other seeds
-                if pub:
-                    toPubQ.put((flag, url, data))
-        except queue.Empty:
-            time.sleep(1)  
+        flag, url, data = q.get()
+        with lockTasks:
+            tasks[url] = (flag, data)
+            #publish to other seeds
+            if pub:
+                toPubQ.put((flag, url, data))
 
 
 def taskPublisher(addr, taskQ):

--- a/util/params.py
+++ b/util/params.py
@@ -22,14 +22,6 @@ BROADCAST_PORT = 4142
 
 List of port usage:
 
-Scrapper:
-main_port(mp): to publish NEW_CLIENT
-mp + 1:        to receive new clients
-
-Dispacher:
-mp:            to push tasks
-mp + 1:        to receive results
-
 Seed:
 mp:            to attend clients
 mp + 1:        to push tasks

--- a/util/params.py
+++ b/util/params.py
@@ -15,6 +15,8 @@ seeds = [(localhost, 8101), (localhost, 9000)]
 
 login = "DISTRIBUTED-SCRAPPER"
 
+BROADCAST_PORT = 4142
+
 #//TODO: Add this description to README.md
 """
 

--- a/util/utils.py
+++ b/util/utils.py
@@ -199,7 +199,7 @@ def findSeeds(seeds, peerQs, deadQs, log, timeout=1000, sleepTime=15, seedFromIn
             else:
                 log.debug("New seed nodes where finded", "Find Seeds")
 
-            for s in tmp - seeds:
+            for s in dif:
                 for q in peerQs:
                     q.put(s)
             seeds.update(tmp)

--- a/util/utils.py
+++ b/util/utils.py
@@ -205,5 +205,11 @@ def findSeeds(seeds, peerQs, deadQs, log, timeout=1000, sleepTime=15):
                     q.put(s)
             seeds.update(tmp)
 
+            if seedFromInput is not None:
+                try:
+                    seeds.add(seedFromInput.get(block=False))
+                except queue.Empty:
+                    pass
+
         #//TODO: Change the amount of the sleep in production
         time.sleep(sleepTime)


### PR DESCRIPTION
Fixes #18 

**Changes:**

- A login method is called next to the creation of a node, for get at least a seed address. If the node is in a remote location(only for dispatcher nodes) an address of a seed node must be given. Otherwise, discovery by broadcast is done and seed nodes available in the network can reply to login attempts.
- If a node `A` is connected to a seed `S`, and `S` crashes, A will notice this and will disconnect from `S` to not send more messages to it. If a new seed `S`' appears and if is reachable, the nodes will automatically connect to `S'`. See commit details for more. Added `discoverPeer`, `getSeeds`, `findSeeds`, `ping`, `disconnectFromSeeds`. All this functions are correctly descripted in the code by comments.
- Update list of port usage in params.py
- The client's user can write a address of a seed node active in a network.txt file in project's root. This is useful if the client is not in the same subnet that the system, and he lose all links to seed nodes. In this case, if he can find an address of an active seed node, he can reconnect to the system without lose all his progress.

**Testing:**
Most cases have been successfully tested.

The thing that most require testing is this case: a remote dispatcher node started with the address of a seed:

- [ ] The node connects, but there are more actives seed nodes, the dispatcher acknowledge this, the initial node crashes, the dispatcher is still connected to the network? 
- [ ] The node connects, and there are more actives seed nodes, but the initial given seed crashes before a `GET_SEED` request is done, What happens next? What is the desired action?