### PR TITLE
Fixes #43 - Add replication and improve scalability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ worker: ## Run a scrapper with default params
 clean: ## Open the Makefile in editor
 	rm downloads/*
 
-%: # If command name exists in folder, it's content is copied to urls
+%: ## If command name exists in folder, it's content is copied to urls
 	cat $(folder)/$@ > urls
 
 help: ## List available commands

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -269,9 +269,9 @@ class Dispatcher:
         log.debug(f"Dispatcher:{self.uuid} disconnecting from system", "dispatch")
         #disconnect
 
-        pWriter.join()
         queue.put(True)
         pFindSeeds.terminate()
+        pInput.terminate()
         
         
 def main(args):

--- a/scrapper.py
+++ b/scrapper.py
@@ -16,6 +16,7 @@ lockSocketNotifier = tLock()
 counterSocketPull = Semaphore(value=0)
 counterSocketNotifier = Semaphore(value=0)
 
+
 def slave(tasks, notifications, idx):
     """
     Child Process of Scrapper, responsable of downloading the urls.

--- a/seed.py
+++ b/seed.py
@@ -598,7 +598,7 @@ class Seed:
 
 def main(args):
     log.setLevel(parseLevel(args.level))
-    s = Seed(args.address, args.port)
+    s = Seed(args.address, args.port, args.replication_limit)
     if not s.login(args.seed):
         log.info("You are not connected to a network", "main") 
     s.serve(args.broadcast_port)
@@ -613,6 +613,7 @@ if __name__ == "__main__":
     parser.add_argument('-b', '--broadcast_port', type=int, default=BROADCAST_PORT, help='broadcast listener port (Default: 4142)')
     parser.add_argument('-l', '--level', type=str, default='DEBUG', help='log level')
     parser.add_argument('-s', '--seed', type=str, default=None, help='address of a existing seed node. Insert as ip_address:port_number')
+    parser.add_argument('-r', '--replication_limit', type=int, default=2, help='maximum number of times that you want data to be replicated')
 
     args = parser.parse_args()
 

--- a/seed.py
+++ b/seed.py
@@ -583,8 +583,8 @@ class Seed:
                     log.debug("GET_DATA received", "serve")
                     try:
                         rep = False
-                        if tasks[msg[1]][0] and tasks[msg[1]][1].data is not None:
-                            rep = tasks[msg[1]][1].dataQ
+                        if self.tasks[msg[1]][0] and self.tasks[msg[1]][1].data is not None:
+                            rep = self.tasks[msg[1]][1].dataQ
                     except KeyError:
                         pass
                     sock.send_pyobj(rep)

--- a/seed.py
+++ b/seed.py
@@ -565,7 +565,7 @@ class Seed:
                 elif msg[0] == "NEW_SEED":
                     log.debug("NEW_SEED received, saving new seed...")
                     #addr = (address, port)
-                    addr = msg[1]
+                    addr = tuple(msg[1])
                     with lockSeeds:
                         self.seeds.append(addr)
                     seedsQ.put(addr)

--- a/util/conit.py
+++ b/util/conit.py
@@ -1,0 +1,41 @@
+class Conit:
+    """
+    Consistency unit, keep a resource and some metrics.
+    """
+    def __init__(self, data, limit=5, owner=None):
+        self.data = data
+        self.hits = 0
+        self.lives = 0
+        self.limit = limit
+        self.owners = list() if owner is None else [owner]
+
+    
+    def hit(self):
+        """
+        Add a hit for this resource, if limit is reached,
+        then its data can be replicated by the caller.
+        """
+        self.hits += 1
+        
+        if self.hits == self.limit:
+            return True
+        return False
+
+
+    def tryOwn(self, repLimit):
+        """
+        Returns True if the resource is in the tolerable replication limit.
+        """
+        return len(self.owners) < repLimit
+
+
+    def addOwner(self, owner):
+        self.owners.append(owner)
+
+    
+    def removeOwner(self, owner):
+        self.owners.remove(owner)
+
+    
+    def addLive(self)
+        self.lives += 1

--- a/util/conit.py
+++ b/util/conit.py
@@ -2,12 +2,12 @@ class Conit:
     """
     Consistency unit, keep a resource and some metrics.
     """
-    def __init__(self, data, limit=5, owner=None):
+    def __init__(self, data, owners, limit=5):
         self.data = data
         self.hits = 0
         self.lives = 0
         self.limit = limit
-        self.owners = list() if owner is None else [owner]
+        self.owners = owners
 
     
     def hit(self):
@@ -30,12 +30,19 @@ class Conit:
 
 
     def addOwner(self, owner):
-        self.owners.append(owner)
+        if owner not in self.owners:
+            self.owners.append(owner)
 
     
     def removeOwner(self, owner):
-        self.owners.remove(owner)
+        if owner in self.owners:
+            self.owners.remove(owner)
 
     
-    def addLive(self)
+    def addLive(self):
         self.lives += 1
+
+    
+    def updateData(self, data, lives=0):
+        self.data = data
+        self.lives = lives


### PR DESCRIPTION
Fixes #43 

**Changes:**
- Create pipeline for replicating data
- Starting more seed nodes now translates into greater storage capacity for the system, thus scalability is improved

**Requires testing:**
Yes. The changes must be tested with multiple seed nodes


**Aditional context:**
- The purger must be updated and upgraded to remove data acording to lives and hit properties of conits
- We need to add feature for disconnect subscriber from crashed seed nodes, and think about whether these crashes should be handled better