### PR TITLE
Fixes #44 - Improve req-res communications between dispatcher and seed

### DIFF
--- a/scrapper.py
+++ b/scrapper.py
@@ -232,7 +232,7 @@ def main(args):
     s = Scrapper(port=args.port, address=args.address)
     if not s.login(args.seed):
         log.info("You are not connected to a network", "main") 
-    s.manage(2)
+    s.manage(args.workers)
 
             
 if __name__ == "__main__":
@@ -243,6 +243,8 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--port', type=int, default=5050, help='connection port')
     parser.add_argument('-l', '--level', type=str, default='DEBUG', help='log level')
     parser.add_argument('-s', '--seed', type=str, default=None, help='address of a existing seed node. Insert as ip_address:port_number')
+    parser.add_argument('-w', '--workers', type=int, default=2, help='number of slaves')
+
 
     args = parser.parse_args()
 

--- a/seed.py
+++ b/seed.py
@@ -577,7 +577,7 @@ class Seed:
                             pushQ.put(url)
                     with lockClients:
                         res = ("RESPONSE", self.package[id])
-                        log.debug(f"Sending package of")
+                        log.debug(f"Sending package of size {len(res)}")
                         sock.send_pyobj(res)
                         self.package[id].clear()
                 elif msg[0] == "GET_TASKS":

--- a/util/utils.py
+++ b/util/utils.py
@@ -242,3 +242,16 @@ def findSeeds(seeds, peerQs, deadQs, log, timeout=1000, sleepTime=15, seedFromIn
 
         #//TODO: Change the amount of the sleep in production
         time.sleep(sleepTime)
+        
+        
+def run_process(target, args):
+    """
+    Run a process and return it's result.
+    """
+    ansQ = Queue()
+    args = args + (ansQ,)
+    process = Process(target=target, args=args)
+    process.start()
+    ans = ansQ.get()
+    process.terminate()
+    return ans


### PR DESCRIPTION
Changes:
- Client send his `uuid` to seeds
- Seeds use the client `uuid` to remember old requests
- When a seed receive a new download, he put it in the package of all interested client