### PR TITLE
Fixes #47 - Update purger

### DIFF
--- a/seed.py
+++ b/seed.py
@@ -97,7 +97,7 @@ def workerAttender(pulledQ, resultQ, failedQ, addr):
             continue
 
 
-def getData(url, owners, resultQ, removeQ):
+def getData(url, address, owners, resultQ, removeQ):
     """
     Process that make a NOBLOCK request to know owners
     of url's data.
@@ -105,8 +105,10 @@ def getData(url, owners, resultQ, removeQ):
     context = zmq.Context()
     sock = noBlockREQ(context, timeout=1000)
 
-    random.shuffle(owners)
-    for o in owners:
+    tempOwners = owners.copy()
+    tempOwners.remove(address)
+    random.shuffle(tempOwners)
+    for o in tempOwners:
         sock.connect(f"tcp://{o}")
         try:
             log.info(f"Requesting data to seed: {o}", "Get Data")
@@ -559,7 +561,7 @@ class Seed:
                                 if res[1].data == None:
                                     #i don't have a local replica, ask owners
                                     getDataQ = Queue()                      
-                                    pGetData = Process(target=getData, name="Get Data", args=(url, res[1].owners, getDataQ, removeQ))
+                                    pGetData = Process(target=getData, name="Get Data", args=(url, (self.addr, self.port), res[1].owners, getDataQ, removeQ))
                                     pGetData.start()
                                     data = getDataQ.get()
                                     pGetData.terminate()

--- a/seed.py
+++ b/seed.py
@@ -105,10 +105,8 @@ def getData(url, address, owners, resultQ, removeQ):
     context = zmq.Context()
     sock = noBlockREQ(context, timeout=1000)
 
-    tempOwners = owners.copy()
-    tempOwners.remove(address)
-    random.shuffle(tempOwners)
-    for o in tempOwners:
+    random.shuffle(owners)
+    for o in owners:
         sock.connect(f"tcp://{o}")
         try:
             log.info(f"Requesting data to seed: {o}", "Get Data")

--- a/seed.py
+++ b/seed.py
@@ -607,13 +607,13 @@ class Seed:
                     try:
                         rep = False
                         if self.tasks[msg[1]][0] and self.tasks[msg[1]][1].data is not None:
-                            rep = self.tasks[msg[1]][1].dataQ
+                            rep = self.tasks[msg[1]][1].data
                     except KeyError:
                         pass
                     sock.send_pyobj(rep)
                 else:
                     sock.send(b"UNKNOWN")      
-            except AssertionError as e:
+            except Exception as e:
                 #Handle connection error
                 log.error(e, "serve")
                 time.sleep(5)

--- a/seed.py
+++ b/seed.py
@@ -3,12 +3,11 @@ from util.conit import Conit
 from multiprocessing import Process, Queue
 from threading import Thread, Lock as tLock
 from util.params import login, BROADCAST_PORT
-from util.utils import parseLevel, LoggerFactory as Logger, noBlockREQ, discoverPeer, getSeeds
+from util.utils import parseLevel, LoggerFactory as Logger, noBlockREQ, discoverPeer, getSeeds, clock
 from socket import socket, AF_INET, SOCK_DGRAM
 
 
 log = Logger(name="Seed")
-pMainLog = "main"
 
 lockTasks = tLock()
 lockSubscriber = tLock()
@@ -136,9 +135,7 @@ def conitCreator(tasks, address, resultQ, toPubQ):
     """
     while True:
         flag, url, data = resultQ.get()
-        log.error(f"There is a task!!!!! ({flag}, {url})", "Conit Creator")
         with lockTasks:
-            log.error("Lock acquired", "Conit Creator")
             if flag:
                 #it comes from workerAttender
                 if url in tasks and tasks[url][0]:
@@ -183,6 +180,7 @@ def removeOwner(tasks, removeQ):
         with lockTasks:
             tasks[url][1].removeOwner(o)
             log.debug(f"Owner {o} removed from conits", "Remove Owner")
+            #//TODO: Publish this removal
 
 
 def updateOwners(owners, conit, owner):
@@ -275,6 +273,9 @@ def taskPublisher(addr, taskQ):
                 header = task[2][0]
                 log.debug(f"Publish {header} of {task[1]}", "Task Publisher")
                 sock.send_multipart([header.encode(), pickle.dumps((task[1], task[2][1]))])
+            elif task[0] == "PURGE":
+                log.debug(f"Publish PURGE", "Task Publisher")
+                sock.send_multipart([b"PURGE", b"JUNK"])
             else:
                 log.debug(f"Publish seed: ({task[0]}:{task[1]})", "Task Publisher")
                 sock.send_multipart([b"NEW_SEED", pickle.dumps(task)])
@@ -292,7 +293,7 @@ def connectToPublishers(sock, peerQ):
             sock.connect(f"tcp://{addr}:{port + 3}")
 
 
-def taskSubscriber(addr, port, peerQ, taskQ, seedQ, dataQ):
+def taskSubscriber(addr, port, peerQ, taskQ, seedQ, dataQ, purgeQ):
     """
     Process that subscribe to published tasks
     """
@@ -303,6 +304,7 @@ def taskSubscriber(addr, port, peerQ, taskQ, seedQ, dataQ):
     sock.setsockopt(zmq.SUBSCRIBE, b"UPDATE")
     sock.setsockopt(zmq.SUBSCRIBE, b"NEW_DATA")
     sock.setsockopt(zmq.SUBSCRIBE, b"FORCED")
+    sock.setsockopt(zmq.SUBSCRIBE, b"PURGE")
 
     #//TODO: Create a disconnectToPublishers
     connectT = Thread(target=connectToPublishers, name="Connect to Publishers", args=(sock, peerQ))
@@ -326,6 +328,8 @@ def taskSubscriber(addr, port, peerQ, taskQ, seedQ, dataQ):
                     peerQ.put((addr, port))
                 elif header == "REMOVE":
                     pass
+                elif header == "PURGE":
+                    purgeQ.put(False)
                 else:
                     #header: UPDATE, NEW_DATA, FORCED
                     #task: (url, data)
@@ -335,23 +339,27 @@ def taskSubscriber(addr, port, peerQ, taskQ, seedQ, dataQ):
             log.error(e, "Task Subscriber")
 
 
-def purger(tasks, cycle):
+def purger(tasks, address, cycle, toPubQ, purgeQ):
     """
-    Thread that purge the downloaded htmls from tasks map when a time cycle occurs.
+    Thread that purge the downloaded data from tasks map when a time cycle occurs.
     """
-    #To not purge posible remote tasks received
-    time.sleep(5)
     while True:
+        pClock = Process(target=clock, args(cycle, purgeQ))
+        pClock.start()
+        pub = purgeQ.get()
+        pClock.terminate()
         with lockTasks:
-            tmpTask = dict()
-            tmpTask.update(tasks)
             log.debug("Starting purge", "Purger")
-            for url in tmpTask:
-                if tmpTask[url][0]:
-                    tasks.pop(url)
+            for url, value in tasks.items():
+                if value[0]:
+                    if value[1].data is not None and value[1].isRemovable():
+                        value[1].data = None
+                        value[1].removeOwner(address)
+                    value[1].addLive()
         log.debug(f"Tasks after purge: {tasks}", "Purger")
         log.debug("Purge finished", "Purger")
-        time.sleep(cycle)
+        if pub:
+            toPubQ.put(("PURGE",))
 
 
 def getRemoteTasks(seed, tasksQ):
@@ -411,7 +419,7 @@ def cloneTasks(tasks:dict):
             liteTasks[key] = value[1].copy()
         else:
             liteTasks[key] = value
-    log.debug(f"Lite copy of tasks created: {liteTasks}", "cloneTasks")
+    log.debug("Lite copy of tasks created", "cloneTasks")
     return liteTasks
 
 
@@ -426,7 +434,7 @@ class Seed:
         self.seeds = [(address, port)]
         self.owners = dict()
 
-        log.debug(f"Seed node created with address:{address}:{port}", pMainLog)
+        log.debug(f"Seed node created with address:{address}:{port}", "main")
 
 
     def login(self, seed):
@@ -489,6 +497,7 @@ class Seed:
         newSeedsQ = Queue()
         removeQ = Queue()
         dataQ = Queue()
+        purgeQ = Queue()
 
         tmp = self.seeds.copy()
         tmp.remove((self.addr, self.port))
@@ -498,7 +507,7 @@ class Seed:
         pPush = Process(target=pushTask, name="Task Pusher", args=(pushQ, f"{self.addr}:{self.port + 1}"))
         pWorkerAttender = Process(target=workerAttender, name="Worker Attender", args=(pulledQ, resultQ, failedQ, f"{self.addr}:{self.port + 2}"))
         pTaskPublisher = Process(target=taskPublisher, name="Task Publisher", args=(f"{self.addr}:{self.port + 3}", taskToPubQ))
-        pTaskSubscriber = Process(target=taskSubscriber, name="Task Subscriber", args=(self.addr, self.port, seedsQ, resultQ, newSeedsQ, dataQ))
+        pTaskSubscriber = Process(target=taskSubscriber, name="Task Subscriber", args=(self.addr, self.port, seedsQ, resultQ, newSeedsQ, dataQ, purgeQ))
         pVerifier = Process(target=verificator, name="Verificator", args=(verificationQ, 800, pushQ))
         pListener = Process(target=broadcastListener, name="Broadcast Listener", args=((self.addr, self.port), broadcastPort))
 
@@ -508,7 +517,7 @@ class Seed:
         resourceManagerT = Thread(target=resourceManager, name="Resource Manager", args=(self.owners, self.tasks, dataQ))
         conitCreatorT = Thread(target=conitCreator, name="Conit Creator", args=(self.tasks, (self.addr, self.port), resultQ, taskToPubQ))
         removeOwnerT = Thread(target=removeOwner, name="Remove Owner", args=(self.owners, removeQ))
-        purgerT = Thread(target=purger, name="Purger", args=(self.tasks, 3000000))
+        purgerT = Thread(target=purger, name="Purger", args=(self.tasks, (self.addr, self.port), 1200, taskToPubQ, purgeQ)) #20 minutes
 
         pPush.start()
         pWorkerAttender.start()

--- a/seed.py
+++ b/seed.py
@@ -401,6 +401,20 @@ def broadcastListener(addr, port):
             sock.sendto(pickle.dumps(("WELCOME", addr)), address)
 
 
+def cloneTasks(tasks:dict):
+    """
+    Helper function that makes a lite copy of tasks, without heavy conits.
+    """
+    liteTasks = dict()
+    for key, value in tasks.items():
+        if value[0]:
+            liteTasks[key] = value[1].copy()
+        else:
+            liteTasks[key] = value
+    log.debug(f"Lite copy of tasks created: {liteTasks}", "cloneTasks")
+    return liteTasks
+
+
 class Seed:
     """
     Represents a seed node, the node that receive and attend all client request.
@@ -561,7 +575,7 @@ class Seed:
                 elif msg[0] == "GET_TASKS":
                     with lockTasks:
                         log.debug("GET_TASK received, sending tasks", "serve")
-                        sock.send_pyobj(self.tasks)
+                        sock.send_pyobj(cloneTasks(self.tasks))
                 elif msg[0] == "NEW_SEED":
                     log.debug("NEW_SEED received, saving new seed...")
                     #addr = (address, port)

--- a/util/conit.py
+++ b/util/conit.py
@@ -41,11 +41,13 @@ class Conit:
     
     def addLive(self):
         self.lives += 1
+        self.hits = 0
 
     
     def updateData(self, data, lives=0):
         self.data = data
         self.lives = lives
+
 
     def copy(self):
         """

--- a/util/conit.py
+++ b/util/conit.py
@@ -57,3 +57,7 @@ class Conit:
         conit.hits = self.hits
         conit.lives = self.lives
         return conit 
+
+
+    def isRemovable(self):
+        return self.hits < self.limit and self.lives

--- a/util/conit.py
+++ b/util/conit.py
@@ -46,3 +46,12 @@ class Conit:
     def updateData(self, data, lives=0):
         self.data = data
         self.lives = lives
+
+    def copy(self):
+        """
+        Returns a copy without data.
+        """
+        conit = Conit(None, self.owners, self.limit)
+        conit.hits = self.hits
+        conit.lives = self.lives
+        return conit 

--- a/util/utils.py
+++ b/util/utils.py
@@ -242,3 +242,11 @@ def findSeeds(seeds, peerQs, deadQs, log, timeout=1000, sleepTime=15, seedFromIn
 
         #//TODO: Change the amount of the sleep in production
         time.sleep(sleepTime)
+
+
+def clock(cycle, q):
+    """
+    Process that notice to the <q> Queue owner when a cycle is passed.
+    """
+    time.sleep(cycle)
+    q.put(True)


### PR DESCRIPTION
Fixes #47 

**Changes:**
- Purger activates when a time cycle completes, or when the system calls a purge. It the first one occurs, the node call the system to a purge
- If a conit is to be purged, his data is set to None and the node's address is removed from conit's owners(in case the node has a replica)
- Fix some errors. See commits descriptions for details

**Require Testing:**
Yes